### PR TITLE
use auto demand to send events to consumers

### DIFF
--- a/lib/backpressureplayground/consumer.ex
+++ b/lib/backpressureplayground/consumer.ex
@@ -2,65 +2,68 @@ defmodule Backpressureplayground.Consumer do
   use GenStage
 
   def start_link do
-    IO.inspect "consumer start link"
+    IO.inspect("consumer start link")
     GenStage.start_link(__MODULE__, %{})
   end
 
   def init(state) do
-    {:consumer, state, subscribe_to: [Backpressureplayground.Producer]}
+    {:consumer, state,
+     subscribe_to: [{Backpressureplayground.Producer, min_demand: 1, max_demand: 10}]}
   end
 
-  def handle_subscribe(:producer, opts, from, producers) do
-    # We will only allow max_demand events every 2000 milliseconds
-    pending = opts[:max_demand] || 5
-    interval = opts[:interval] || 2000
+  # def handle_subscribe(:producer, opts, from, producers) do
+  ## We will only allow max_demand events every 2000 milliseconds
+  # pending = opts[:max_demand] || 5
+  # interval = opts[:interval] || 500
 
-    # Register the producer in the state
-    producers = Map.put(producers, from, {pending, interval})
-    # Ask for the pending events and schedule the next time around
-    producers = ask_and_schedule(producers, from)
+  ## Register the producer in the state
+  # producers = Map.put(producers, from, {pending, interval})
+  ## Ask for the pending events and schedule the next time around
+  # producers = ask_and_schedule(producers, from)
 
-    # Returns manual as we want control over the demand
-    {:manual, producers}
-  end
+  ## Returns manual as we want control over the demand
+  # {:manual, producers}
+  # end
 
-  def handle_cancel(_, from, producers) do
-    # Remove the producers from the map on unsubscribe
-    {:noreply, [], Map.delete(producers, from)}
-  end
+  # def handle_cancel(_, from, producers) do
+  ## Remove the producers from the map on unsubscribe
+  # {:noreply, [], Map.delete(producers, from)}
+  # end
 
-  def handle_info({:ask, from}, producers) do
-    # This callback is invoked by the Process.send_after/3 message below.
-    {:noreply, [], ask_and_schedule(producers, from)}
-  end
+  # def handle_info({:ask, from}, producers) do
+  ## This callback is invoked by the Process.send_after/3 message below.
+  # {:noreply, [], ask_and_schedule(producers, from)}
+  # end
 
-  defp ask_and_schedule(producers, from) do
-    case producers do
-      %{^from => {pending, interval}} ->
-        # IO.inspect "pending"
-        # IO.inspect pending
-        # Ask for any pending events
-        GenStage.ask(from, pending)
-        # And let's check again after interval
-        Process.send_after(self(), {:ask, from}, interval)
-        # Finally, reset pending events to 0
-        Map.put(producers, from, {0, interval})
-      %{} ->
-        producers
-    end
-  end
+  # defp ask_and_schedule(producers, from) do
+  # case producers do
+  # %{^from => {pending, interval}} ->
+  ## IO.inspect "pending"
+  ## IO.inspect pending
+  ## Ask for any pending events
+  # GenStage.ask(from, pending)
+  ## And let's check again after interval
+  # Process.send_after(self(), {:ask, from}, interval)
+  ## Finally, reset pending events to 0
+  # Map.put(producers, from, {0, interval})
+
+  # %{} ->
+  # producers
+  # end
+  # end
 
   @spec handle_events(any, any, any) :: {:noreply, [], any}
-  def handle_events(events, _from, producers) do
-    # Bump the amount of pending events for the given producer
-    IO.inspect "handle_events"
-    IO.inspect events
+  def handle_events('\t', _from, producers), do: {:noreply, [], producers}
 
-    #producers = Map.update!(producers, from, fn {pending, interval} ->
-      # IO.inspect "events-loop"
-      # IO.inspect events
-      #{pending + length(events), interval}
-    #end)
+  def handle_events(events, _from, producers) when is_list(events) do
+    # Bump the amount of pending events for the given producer
+    IO.puts("consumer events: #{inspect(events)}")
+
+    # producers = Map.update!(producers, from, fn {pending, interval} ->
+    # IO.inspect "events-loop"
+    # IO.inspect events
+    # {pending + length(events), interval}
+    # end)
 
     # Consume the events by printing them.
     # IO.inspect(events)
@@ -69,4 +72,6 @@ defmodule Backpressureplayground.Consumer do
     # A producer_consumer would return the processed events here.
     {:noreply, [], producers}
   end
+
+  def handle_events(_events, _from, producers), do: {:noreply, [], producers}
 end

--- a/lib/backpressureplayground/producer.ex
+++ b/lib/backpressureplayground/producer.ex
@@ -2,38 +2,26 @@ defmodule Backpressureplayground.Producer do
   use GenStage
 
   def start_link(initial \\ 0) do
-    IO.inspect "node"
-    IO.inspect node()
     GenStage.start_link(__MODULE__, initial, name: __MODULE__)
   end
 
-  def init(_counter), do: {:producer, []}
+  def init(_counter), do: {:producer, %{events: []}}
 
-  def add(), do: GenServer.cast(__MODULE__, {:add, 0..10 |> Enum.to_list()})
+  def add(), do: GenServer.cast(__MODULE__, {:add, Enum.to_list(0..10)})
 
   def handle_cast({:add, events}, state) do
     # IO.inspect "add"
     # IO.inspect events
     # {:noreply, events, state} -> Add events directly to consumer
     # {:noreply, events, events} -> Add events to state, to later be demanded by consumer
-    IO.inspect "adding this:"
-    IO.inspect state
-    {:noreply, events, events}
+    IO.puts("producer events: #{inspect(events)}")
+
+    {:noreply, events, %{events: events}}
   end
 
-  def handle_demand(demand, state) do
-    # IO.inspect "demand"
-    # IO.inspect demand
-    # IO.inspect Enum.split(state, demand)
-    IO.inspect "state"
-    IO.inspect state
-    # IO.inspect "demand"
-    # IO.inspect demand
-    case Enum.split(state, demand) do
-      {events_to_be_sent, []} ->
-        {:noreply, events_to_be_sent, []}
-      {events_to_be_sent, remainings} ->
-        {:noreply, events_to_be_sent, remainings}
-    end
+  def handle_demand(demand, %{events: events}) do
+    {to_send_events, remain_evens} = Enum.split(events, demand)
+    IO.puts("producer remaining events: #{inspect(remain_evens)}")
+    {:noreply, to_send_events, %{events: remain_evens}}
   end
 end


### PR DESCRIPTION
just run a node and execute `GenServer.cast Backpressureplayground.Producer {:add, Enum.to_list(0..100)}`